### PR TITLE
Text content fix

### DIFF
--- a/transforms/integration/__testfixtures__/default-component-test.output.js
+++ b/transforms/integration/__testfixtures__/default-component-test.output.js
@@ -13,7 +13,7 @@ test('it renders', function(assert) {
 
   this.render(hbs`{{foo-bar}}`);
 
-  assert.equal(find('*').textContent.trim(), '');
+  assert.equal(this.element.textContent.trim(), '');
 
   // Template block usage:
   this.render(hbs`
@@ -22,5 +22,5 @@ test('it renders', function(assert) {
     {{/foo-barl}}
   `);
 
-  assert.equal(find('*').textContent.trim(), 'template block text');
+  assert.equal(this.element.textContent.trim(), 'template block text');
 });

--- a/transforms/integration/__testfixtures__/default-component-test.output.js
+++ b/transforms/integration/__testfixtures__/default-component-test.output.js
@@ -1,4 +1,3 @@
-import { find } from '@ember/test-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/transforms/integration/__testfixtures__/text.input.js
+++ b/transforms/integration/__testfixtures__/text.input.js
@@ -10,3 +10,9 @@ test('it renders', function(assert) {
 
   assert.equal(this.$('.foo').text().trim(), '');
 });
+
+test('it renders', function(assert) {
+  this.render(hbs`{{foo-bar}}`);
+
+  assert.equal(this.$().text().trim(), '');
+});

--- a/transforms/integration/__testfixtures__/text.output.js
+++ b/transforms/integration/__testfixtures__/text.output.js
@@ -11,3 +11,9 @@ test('it renders', function(assert) {
 
   assert.equal(find('.foo').textContent.trim(), '');
 });
+
+test('it renders', function(assert) {
+  this.render(hbs`{{foo-bar}}`);
+
+  assert.equal(this.element.textContent.trim(), '');
+});

--- a/transforms/integration/transforms/text.js
+++ b/transforms/integration/transforms/text.js
@@ -11,6 +11,15 @@ const { createFindExpression, isJQuerySelectExpression, addImportStatement, writ
  * @returns {*}
  */
 function createExpression(j, findArgs) {
+  if (findArgs.length === 0) {
+    return j.memberExpression(
+      j.memberExpression(
+        j.thisExpression(),
+        j.identifier('element')
+      ),
+      j.identifier('textContent')
+    );
+  }
   return j.memberExpression(
     createFindExpression(j, findArgs),
     j.identifier('textContent')

--- a/transforms/native-dom/__testfixtures__/context-argument.output.js
+++ b/transforms/native-dom/__testfixtures__/context-argument.output.js
@@ -1,4 +1,4 @@
-import { find, findAll, visit, click, fillIn } from '@ember/test-helpers';
+import { find, findAll, visit, click } from '@ember/test-helpers';
 import { test } from 'qunit';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 

--- a/transforms/native-dom/__testfixtures__/double-import.input.js
+++ b/transforms/native-dom/__testfixtures__/double-import.input.js
@@ -1,2 +1,9 @@
 import { click, currentURL } from 'ember-native-dom-helpers';
 import { find, visit } from 'ember-native-dom-helpers';
+
+test('visiting /foo', async function(assert) {
+  await visit('/foo');
+  await click('.foo');
+  assert.ok(find('.foo'));
+  assert.ok(currentURL());
+});

--- a/transforms/native-dom/__testfixtures__/double-import.output.js
+++ b/transforms/native-dom/__testfixtures__/double-import.output.js
@@ -1,1 +1,8 @@
 import { click, currentURL, find, visit } from '@ember/test-helpers';
+
+test('visiting /foo', async function(assert) {
+  await visit('/foo');
+  await click('.foo');
+  assert.ok(find('.foo'));
+  assert.ok(currentURL());
+});

--- a/transforms/native-dom/__testfixtures__/prune-import.input.js
+++ b/transforms/native-dom/__testfixtures__/prune-import.input.js
@@ -1,1 +1,3 @@
 import { click } from 'ember-native-dom-helpers';
+
+click('.foo');

--- a/transforms/native-dom/__testfixtures__/prune-import.output.js
+++ b/transforms/native-dom/__testfixtures__/prune-import.output.js
@@ -1,1 +1,3 @@
 import { click } from '@ember/test-helpers';
+
+click('.foo');

--- a/transforms/utils.js
+++ b/transforms/utils.js
@@ -360,13 +360,25 @@ function writeImportStatements(j, root) {
       source: { value: '@ember/test-helpers' }
     });
 
+    let actuallyNeedsImport = Array.from(_statementsToImport).filter(methodName => {
+      return root.find(j.CallExpression, {
+        callee: {
+          name: methodName
+        }
+      }).length > 0;
+    });
+
+    if (actuallyNeedsImport.length === 0) {
+      return;
+    }
+
     if (importStatement.length === 0) {
-      importStatement = createImportStatement(j, '@ember/test-helpers', 'default', Array.from(_statementsToImport));
+      importStatement = createImportStatement(j, '@ember/test-helpers', 'default', actuallyNeedsImport);
       body.unshift(importStatement);
     } else {
       let existingSpecifiers = importStatement.get("specifiers");
 
-      _statementsToImport.forEach(name => {
+      actuallyNeedsImport.forEach(name => {
         if (existingSpecifiers.filter(exSp => exSp.value.imported.name === name).length === 0) {
           existingSpecifiers.push(j.importSpecifier(j.identifier(name)));
         }


### PR DESCRIPTION
In integration tests, when rewriting `this.$().text()`, write `this.element.textContent` instead of `find('*').textContent`. The latter only returns one node, not the entirety of the text content within the `this.element`.

I also updated the write imports helper to only write imports to `click/findAll/fillIn/find/etc` for ember test helpers if they are actually used. The codemod was generating some lint errors because some of the rules added imports un-necessarily. Doing this at the time of writing imports allows each transform to add an import without worrying about whether or not it will cause a lint error. (This is why you'll see updates to unrelated tests).