### PR TITLE
add transform for migrating deprecated ember-test-helpers API

### DIFF
--- a/transforms/ember-test-helper-api-migration/README.md
+++ b/transforms/ember-test-helper-api-migration/README.md
@@ -1,0 +1,75 @@
+# ember-test-helper-api-migration
+This codemod transfer is to migrate deprecated nameplace `ember-test-helpers` to nameplace `@ember/test-helpers`
+
+## Usage
+
+```
+npx ember-test-helpers-codemod ember-test-helper-api-migration path/of/files/ or/some**/*glob.js
+
+# or
+
+yarn global add ember-test-helpers-codemod
+ember-test-helpers-codemod ember-test-helper-api-migration path/of/files/ or/some**/*glob.js
+```
+
+## Input / Output
+
+<!--FIXTURES_TOC_START-->
+* [basic](#basic)
+* [do-not-have-@ember-test-helpers-import](#do-not-have-@ember-test-helpers-import)
+* [do-not-have-ember-test-helpers-import](#do-not-have-ember-test-helpers-import)
+<!--FIXTURES_TOC_END-->
+
+<!--FIXTURES_CONTENT_START-->
+---
+<a id="basic">**basic**</a>
+
+**Input** (<small>[basic.input.js](transforms/ember-test-helper-api-migration/__testfixtures__/basic.input.js)</small>):
+```js
+import { setApplication } from '@ember/test-helpers';
+import { start } from 'ember-qunit';
+import { setResolver } from 'ember-test-helpers';
+```
+
+**Output** (<small>[basic.input.js](transforms/ember-test-helper-api-migration/__testfixtures__/basic.output.js)</small>):
+```js
+import { setApplication, setResolver } from '@ember/test-helpers';
+import { start } from 'ember-qunit';
+```
+---
+<a id="do-not-have-@ember-test-helpers-import">**do-not-have-@ember-test-helpers-import**</a>
+
+**Input** (<small>[do-not-have-@ember-test-helpers-import.input.js](transforms/ember-test-helper-api-migration/__testfixtures__/do-not-have-@ember-test-helpers-import.input.js)</small>):
+```js
+import { start } from 'ember-qunit';
+import { setResolver } from 'ember-test-helpers';
+```
+
+**Output** (<small>[do-not-have-@ember-test-helpers-import.input.js](transforms/ember-test-helper-api-migration/__testfixtures__/do-not-have-@ember-test-helpers-import.output.js)</small>):
+```js
+import { setResolver } from '@ember/test-helpers';
+import { start } from 'ember-qunit';
+```
+---
+<a id="do-not-have-ember-test-helpers-import">**do-not-have-ember-test-helpers-import**</a>
+
+**Input** (<small>[do-not-have-ember-test-helpers-import.input.js](transforms/ember-test-helper-api-migration/__testfixtures__/do-not-have-ember-test-helpers-import.input.js)</small>):
+```js
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('foo-bar', 'Integration | Component | foo bar', {
+  integration: true
+});
+```
+
+**Output** (<small>[do-not-have-ember-test-helpers-import.input.js](transforms/ember-test-helper-api-migration/__testfixtures__/do-not-have-ember-test-helpers-import.output.js)</small>):
+```js
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('foo-bar', 'Integration | Component | foo bar', {
+  integration: true
+});
+```
+<!--FIXTURE_CONTENT_END-->

--- a/transforms/ember-test-helper-api-migration/README.md
+++ b/transforms/ember-test-helper-api-migration/README.md
@@ -1,5 +1,5 @@
 # ember-test-helper-api-migration
-This codemod transfer is to migrate deprecated nameplace `ember-test-helpers` to nameplace `@ember/test-helpers`
+This codemod transfer is to migrate deprecated package `ember-test-helpers` to package `@ember/test-helpers`
 
 ## Usage
 

--- a/transforms/ember-test-helper-api-migration/__testfixtures__/basic.input.js
+++ b/transforms/ember-test-helper-api-migration/__testfixtures__/basic.input.js
@@ -1,0 +1,3 @@
+import { setApplication } from '@ember/test-helpers';
+import { start } from 'ember-qunit';
+import { setResolver } from 'ember-test-helpers';

--- a/transforms/ember-test-helper-api-migration/__testfixtures__/basic.input.js
+++ b/transforms/ember-test-helper-api-migration/__testfixtures__/basic.input.js
@@ -1,3 +1,8 @@
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
 import { setResolver } from 'ember-test-helpers';
+
+setResolver(engineResolverFor('shared-components'));
+
+setApplication(Application.create(config.APP));
+preloadAssets(manifest).then(start);

--- a/transforms/ember-test-helper-api-migration/__testfixtures__/basic.output.js
+++ b/transforms/ember-test-helper-api-migration/__testfixtures__/basic.output.js
@@ -1,2 +1,7 @@
 import { setApplication, setResolver } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
+
+setResolver(engineResolverFor('shared-components'));
+
+setApplication(Application.create(config.APP));
+preloadAssets(manifest).then(start);

--- a/transforms/ember-test-helper-api-migration/__testfixtures__/basic.output.js
+++ b/transforms/ember-test-helper-api-migration/__testfixtures__/basic.output.js
@@ -1,0 +1,2 @@
+import { setApplication, setResolver } from '@ember/test-helpers';
+import { start } from 'ember-qunit';

--- a/transforms/ember-test-helper-api-migration/__testfixtures__/do-not-have-@ember-test-helpers-import.input.js
+++ b/transforms/ember-test-helper-api-migration/__testfixtures__/do-not-have-@ember-test-helpers-import.input.js
@@ -1,0 +1,2 @@
+import { start } from 'ember-qunit';
+import { setResolver } from 'ember-test-helpers';

--- a/transforms/ember-test-helper-api-migration/__testfixtures__/do-not-have-@ember-test-helpers-import.input.js
+++ b/transforms/ember-test-helper-api-migration/__testfixtures__/do-not-have-@ember-test-helpers-import.input.js
@@ -1,2 +1,7 @@
 import { start } from 'ember-qunit';
 import { setResolver } from 'ember-test-helpers';
+
+setResolver(engineResolverFor('shared-components')); 
+ 
+setApplication(Application.create(config.APP)); 
+preloadAssets(manifest).then(start); 

--- a/transforms/ember-test-helper-api-migration/__testfixtures__/do-not-have-@ember-test-helpers-import.output.js
+++ b/transforms/ember-test-helper-api-migration/__testfixtures__/do-not-have-@ember-test-helpers-import.output.js
@@ -1,0 +1,2 @@
+import { setResolver } from '@ember/test-helpers';
+import { start } from 'ember-qunit';

--- a/transforms/ember-test-helper-api-migration/__testfixtures__/do-not-have-@ember-test-helpers-import.output.js
+++ b/transforms/ember-test-helper-api-migration/__testfixtures__/do-not-have-@ember-test-helpers-import.output.js
@@ -1,2 +1,7 @@
 import { setResolver } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
+
+setResolver(engineResolverFor('shared-components')); 
+ 
+setApplication(Application.create(config.APP)); 
+preloadAssets(manifest).then(start); 

--- a/transforms/ember-test-helper-api-migration/__testfixtures__/do-not-have-ember-test-helpers-import.input.js
+++ b/transforms/ember-test-helper-api-migration/__testfixtures__/do-not-have-ember-test-helpers-import.input.js
@@ -1,0 +1,6 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('foo-bar', 'Integration | Component | foo bar', {
+  integration: true
+});

--- a/transforms/ember-test-helper-api-migration/__testfixtures__/do-not-have-ember-test-helpers-import.output.js
+++ b/transforms/ember-test-helper-api-migration/__testfixtures__/do-not-have-ember-test-helpers-import.output.js
@@ -1,0 +1,6 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('foo-bar', 'Integration | Component | foo bar', {
+  integration: true
+});

--- a/transforms/ember-test-helper-api-migration/index.js
+++ b/transforms/ember-test-helper-api-migration/index.js
@@ -1,0 +1,47 @@
+const { getParser } = require('codemod-cli').jscodeshift;
+const { addImportStatement, writeImportStatements } = require('../utils');
+
+module.exports = function transformer(file, api) {
+  const j = getParser(api);
+  const root = j(file.source);
+
+  /**
+   * Transform imports from ember-test-helpers to @ember/test-helpers
+   */
+  function transform() {
+    let deprecatedEmberTestHelperStatements = root.find(j.ImportDeclaration, {
+      source: { value: 'ember-test-helpers'}
+    })
+
+    if (deprecatedEmberTestHelperStatements.length === 0) {
+      return root.toSource({
+        quote: 'single',
+        trailingComma: true,
+      });
+    }
+
+    let newImports = [];
+
+    deprecatedEmberTestHelperStatements.forEach((importStatement) => {
+      let oldSpecifiers = importStatement.get('specifiers');
+  
+      oldSpecifiers.each(({ node: specifier }) => {
+        let importedName = specifier.imported.name;
+        newImports.push(importedName)
+      });
+
+      // Remove "ember-test-helper" import statement
+      j(importStatement).remove();
+    });
+  
+    addImportStatement(newImports);
+    writeImportStatements(j, root);
+  }
+
+  transform();
+
+  return root.toSource({
+    quote: 'single',
+    trailingComma: true,
+  });
+}

--- a/transforms/ember-test-helper-api-migration/test.js
+++ b/transforms/ember-test-helper-api-migration/test.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const { runTransformTest } = require('codemod-cli');
+
+runTransformTest({
+  type: 'jscodeshift',
+  name: 'ember-test-helper-api-migration',
+});


### PR DESCRIPTION
### Description
Add this transform for migrating deprecated `ember-test-helpers` import to `@ember/test-helpers`.

Example:
from 
```
import { setApplication } from '@ember/test-helpers';
import { setResolver } from 'ember-test-helpers';
```
to 
```
import { setApplication, setResolver } from '@ember/test-helpers';
```

### Test
codemod-cli test

 PASS  transforms/find/test.js


 PASS  transforms/ember-test-helper-api-migration/test.js

 PASS  transforms/native-dom/test.js

 PASS  transforms/acceptance/test.js
 PASS  transforms/integration/test.js

Test Suites: 5 passed, 5 total
Tests:       92 passed, 92 total
Snapshots:   0 total
Time:        3.502s, estimated 4s
Ran all test suites matching /test/i.