### PR TITLE
add transform to replace deprecated this.render()

### DIFF
--- a/transforms/this-render-migration/README.md
+++ b/transforms/this-render-migration/README.md
@@ -1,0 +1,79 @@
+# this-render-migration
+This codemod transform is to replace deprecated this.render() with render() from '@ember/test-helpers' package
+
+## Usage
+
+```
+npx ember-test-helpers-codemod this-render-migration path/of/files/ or/some**/*glob.js
+
+# or
+
+yarn global add ember-test-helpers-codemod
+ember-test-helpers-codemod this-render-migration path/of/files/ or/some**/*glob.js
+```
+
+## Input / Output
+
+<!--FIXTURES_TOC_START-->
+* [basic](#basic)
+* [has-no-ember-test-helpers-import](#has-no-ember-test-helpers-import)
+<!--FIXTURES_TOC_END-->
+
+<!--FIXTURES_CONTENT_START-->
+---
+<a id="basic">**basic**</a>
+
+**Input** (<small>[basic.input.js](transforms/this-render-migration/__testfixtures__/basic.input.js)</small>):
+```js
+import { click } from '@ember/test-helpers';
+
+test('It handles switching selected option on click and fires onSelect event', async function(assert) {
+    this.onSelectMock = this.sandbox.stub();
+    await this.render(hbs`
+      <Common::TimeCommitmentSelector @timeCommitmentOptions={{timeCommitmentOptionsMock}} @onSelect={{onSelectMock}}>
+      </Common::TimeCommitmentSelector>
+    `);
+})
+
+```
+
+**Output** (<small>[basic.input.js](transforms/this-render-migration/__testfixtures__/basic.output.js)</small>):
+```js
+import { click, render } from '@ember/test-helpers';
+
+test('It handles switching selected option on click and fires onSelect event', async function(assert) {
+    this.onSelectMock = this.sandbox.stub();
+    await render(hbs`
+      <Common::TimeCommitmentSelector @timeCommitmentOptions={{timeCommitmentOptionsMock}} @onSelect={{onSelectMock}}>
+      </Common::TimeCommitmentSelector>
+    `);
+})
+```
+---
+<a id="has-no-ember-test-helpers-import">**has-no-ember-test-helpers-import**</a>
+
+**Input** (<small>[has-no-ember-test-helpers-import.input.js](transforms/this-render-migration/__testfixtures__/has-no-ember-test-helpers-import.input.js)</small>):
+```js
+test('It handles switching selected option on click and fires onSelect event', async function(assert) {
+    this.onSelectMock = this.sandbox.stub();
+    await this.render(hbs`
+      <Common::TimeCommitmentSelector @timeCommitmentOptions={{timeCommitmentOptionsMock}} @onSelect={{onSelectMock}}>
+      </Common::TimeCommitmentSelector>
+    `);
+})
+
+```
+
+**Output** (<small>[has-no-ember-test-helpers-import.input.js](transforms/this-render-migration/__testfixtures__/has-no-ember-test-helpers-import.output.js)</small>):
+```js
+import { render } from '@ember/test-helpers';
+test('It handles switching selected option on click and fires onSelect event', async function(assert) {
+    this.onSelectMock = this.sandbox.stub();
+    await render(hbs`
+      <Common::TimeCommitmentSelector @timeCommitmentOptions={{timeCommitmentOptionsMock}} @onSelect={{onSelectMock}}>
+      </Common::TimeCommitmentSelector>
+    `);
+})
+
+```
+<!--FIXTURE_CONTENT_END-->

--- a/transforms/this-render-migration/__testfixtures__/basic.input.js
+++ b/transforms/this-render-migration/__testfixtures__/basic.input.js
@@ -1,0 +1,9 @@
+import { click } from '@ember/test-helpers';
+
+test('It handles switching selected option on click and fires onSelect event', async function(assert) {
+    this.onSelectMock = this.sandbox.stub();
+    await this.render(hbs`
+      <Common::TimeCommitmentSelector @timeCommitmentOptions={{timeCommitmentOptionsMock}} @onSelect={{onSelectMock}}>
+      </Common::TimeCommitmentSelector>
+    `);
+})

--- a/transforms/this-render-migration/__testfixtures__/basic.output.js
+++ b/transforms/this-render-migration/__testfixtures__/basic.output.js
@@ -1,0 +1,9 @@
+import { click, render } from '@ember/test-helpers';
+
+test('It handles switching selected option on click and fires onSelect event', async function(assert) {
+    this.onSelectMock = this.sandbox.stub();
+    await render(hbs`
+      <Common::TimeCommitmentSelector @timeCommitmentOptions={{timeCommitmentOptionsMock}} @onSelect={{onSelectMock}}>
+      </Common::TimeCommitmentSelector>
+    `);
+})

--- a/transforms/this-render-migration/__testfixtures__/has-no-ember-test-helpers-import.input.js
+++ b/transforms/this-render-migration/__testfixtures__/has-no-ember-test-helpers-import.input.js
@@ -1,0 +1,7 @@
+test('It handles switching selected option on click and fires onSelect event', async function(assert) {
+    this.onSelectMock = this.sandbox.stub();
+    await this.render(hbs`
+      <Common::TimeCommitmentSelector @timeCommitmentOptions={{timeCommitmentOptionsMock}} @onSelect={{onSelectMock}}>
+      </Common::TimeCommitmentSelector>
+    `);
+})

--- a/transforms/this-render-migration/__testfixtures__/has-no-ember-test-helpers-import.output.js
+++ b/transforms/this-render-migration/__testfixtures__/has-no-ember-test-helpers-import.output.js
@@ -1,0 +1,8 @@
+import { render } from '@ember/test-helpers';
+test('It handles switching selected option on click and fires onSelect event', async function(assert) {
+    this.onSelectMock = this.sandbox.stub();
+    await render(hbs`
+      <Common::TimeCommitmentSelector @timeCommitmentOptions={{timeCommitmentOptionsMock}} @onSelect={{onSelectMock}}>
+      </Common::TimeCommitmentSelector>
+    `);
+})

--- a/transforms/this-render-migration/index.js
+++ b/transforms/this-render-migration/index.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const { getParser } = require('codemod-cli').jscodeshift;
+const { addImportStatement, writeImportStatements } = require('../utils');
+
+module.exports = function transformer(file, api) {
+  const j = getParser(api);
+  const root = j(file.source);
+
+  /**
+   * Replace deprecated this.render() with render() from '@ember/test-helpers' package
+   */
+  function transform() {
+    root.find(j.ExpressionStatement, {
+      expression: {
+        type: 'AwaitExpression',
+        argument: {
+        	type: 'CallExpression',
+          callee: {
+            type: 'MemberExpression',
+            object: {
+              type: 'ThisExpression'
+            },
+            property: {
+              type: 'Identifier',
+              name: 'render'
+            },
+          },
+        },
+      },
+    }).replaceWith(path => {
+      let oldCallExpressionArguments = path.node.expression.argument.arguments;
+
+		  return j.expressionStatement(
+        j.awaitExpression(
+          j.callExpression(
+            j.identifier('render'), 
+            oldCallExpressionArguments
+          )
+        )
+      )
+    })
+
+    let newImports = ['render'];
+
+    addImportStatement(newImports);
+    writeImportStatements(j, root);
+  }
+
+  transform();
+
+  return root.toSource({
+    quote: 'single',
+    trailingComma: true,
+  });
+}

--- a/transforms/this-render-migration/index.js
+++ b/transforms/this-render-migration/index.js
@@ -11,33 +11,23 @@ module.exports = function transformer(file, api) {
    * Replace deprecated this.render() with render() from '@ember/test-helpers' package
    */
   function transform() {
-    root.find(j.ExpressionStatement, {
-      expression: {
-        type: 'AwaitExpression',
-        argument: {
-        	type: 'CallExpression',
-          callee: {
-            type: 'MemberExpression',
-            object: {
-              type: 'ThisExpression'
-            },
-            property: {
-              type: 'Identifier',
-              name: 'render'
-            },
-          },
+    root.find(j.CallExpression, {
+      callee: {
+        type: 'MemberExpression',
+        object: {
+          type: 'ThisExpression'
+        },
+        property: {
+          type: 'Identifier',
+          name: 'render'
         },
       },
     }).replaceWith(path => {
-      let oldCallExpressionArguments = path.node.expression.argument.arguments;
+      let oldCallExpressionArguments = path.node.arguments;
 
-		  return j.expressionStatement(
-        j.awaitExpression(
-          j.callExpression(
-            j.identifier('render'), 
-            oldCallExpressionArguments
-          )
-        )
+      return j.callExpression(
+        j.identifier('render'), 
+        oldCallExpressionArguments
       )
     })
 

--- a/transforms/this-render-migration/test.js
+++ b/transforms/this-render-migration/test.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const { runTransformTest } = require('codemod-cli');
+
+runTransformTest({
+  type: 'jscodeshift',
+  name: 'this-render-migration',
+});


### PR DESCRIPTION
### Description 
add transform to replace deprecated this.render() with render() from '@ember/test-helpers' package. Example:
From
```
import { click } from '@ember/test-helpers';

test('It handles switching selected option on click and fires onSelect event', async function(assert) {
    this.onSelectMock = this.sandbox.stub();
    await this.render(hbs`
      <Common::TimeCommitmentSelector @timeCommitmentOptions={{timeCommitmentOptionsMock}} @onSelect={{onSelectMock}}>
      </Common::TimeCommitmentSelector>
    `);
})
```
to
```
import { click, render } from '@ember/test-helpers';

test('It handles switching selected option on click and fires onSelect event', async function(assert) {
    this.onSelectMock = this.sandbox.stub();
    await render(hbs`
      <Common::TimeCommitmentSelector @timeCommitmentOptions={{timeCommitmentOptionsMock}} @onSelect={{onSelectMock}}>
      </Common::TimeCommitmentSelector>
    `);
})
```

### Test
 PASS  transforms/find/test.js
 PASS  transforms/native-dom/test.js
 PASS  transforms/this-render-migration/test.js
 PASS  transforms/acceptance/test.js
 PASS  transforms/integration/test.js

Test Suites: 5 passed, 5 total
Tests:       90 passed, 90 total
Snapshots:   0 total
Time:        3.301s, estimated 4s
Ran all test suites matching /test/i.