### PR TITLE
add update triggerEvent param

### DIFF
--- a/transforms/update-triggerevent-file-param/README.md
+++ b/transforms/update-triggerevent-file-param/README.md
@@ -1,0 +1,50 @@
+# update-triggerevent-file-param
+A transform to update param in `triggerEvent` from `[ file ]` to `{ files: [ file ] }`
+
+## Usage
+
+```
+npx ember-test-helpers-codemod update-triggerevent-file-param path/of/files/ or/some**/*glob.js
+
+# or
+
+yarn global add ember-test-helpers-codemod
+ember-test-helpers-codemod update-triggerevent-file-param path/of/files/ or/some**/*glob.js
+```
+
+## Input / Output
+
+<!--FIXTURES_TOC_START-->
+* [basic](#basic)
+<!--FIXTURES_TOC_END-->
+
+<!--FIXTURES_CONTENT_START-->
+---
+<a id="basic">**basic**</a>
+
+**Input** (<small>[basic.input.js](transforms/update-triggerevent-file-param/__testfixtures__/basic.input.js)</small>):
+```js
+import { triggerEvent } from '@ember/test-helpers';
+
+test('test', async function(assert) {
+    await triggerEvent('[data-test-file-upload-button__input]', 'change', [file]);
+    await triggerEvent('[data-test-file-upload-button__input]', 'change', []);
+});
+
+```
+
+**Output** (<small>[basic.input.js](transforms/update-triggerevent-file-param/__testfixtures__/basic.output.js)</small>):
+```js
+import { triggerEvent } from '@ember/test-helpers';
+
+test('test', async function(assert) {
+    await triggerEvent('[data-test-file-upload-button__input]', 'change', {
+        files: [file]
+    });
+    await triggerEvent('[data-test-file-upload-button__input]', 'change', {
+        files: []
+    });
+});
+
+```
+<!--FIXTURE_CONTENT_END-->

--- a/transforms/update-triggerevent-file-param/__testfixtures__/basic.input.js
+++ b/transforms/update-triggerevent-file-param/__testfixtures__/basic.input.js
@@ -1,0 +1,6 @@
+import { triggerEvent } from '@ember/test-helpers';
+
+test('test', async function(assert) {
+    await triggerEvent('[data-test-file-upload-button__input]', 'change', [file]);
+    await triggerEvent('[data-test-file-upload-button__input]', 'change', []);
+});

--- a/transforms/update-triggerevent-file-param/__testfixtures__/basic.output.js
+++ b/transforms/update-triggerevent-file-param/__testfixtures__/basic.output.js
@@ -1,0 +1,10 @@
+import { triggerEvent } from '@ember/test-helpers';
+
+test('test', async function(assert) {
+    await triggerEvent('[data-test-file-upload-button__input]', 'change', {
+        files: [file]
+    });
+    await triggerEvent('[data-test-file-upload-button__input]', 'change', {
+        files: []
+    });
+});

--- a/transforms/update-triggerevent-file-param/index.js
+++ b/transforms/update-triggerevent-file-param/index.js
@@ -1,0 +1,29 @@
+const { getParser } = require('codemod-cli').jscodeshift;
+
+module.exports = function transformer(file, api) {
+  const j = getParser(api);
+  const root = j(file.source);
+
+  /**
+   * A transform to update param in `triggerEvent` from `[ file ]` to `{ files: [ file ] }`
+   */
+  function transform() {
+    root.find(j.CallExpression, {
+      callee: {
+        name: 'triggerEvent'
+      }
+    }).find(j.ArrayExpression).replaceWith(path => {
+      // make sure we just modify the arrayExpression which is the param of triggerEvent call expression
+      if (path.parent.node.type === 'CallExpression' && path.parent.node.callee.name === 'triggerEvent'){
+        return j.objectExpression([j.property('init',j.identifier('files'), path.node)])
+      } else return path.node
+    })
+  }
+
+  transform();
+
+  return root.toSource({
+    quote: 'single',
+    trailingComma: false,
+  });
+}

--- a/transforms/update-triggerevent-file-param/test.js
+++ b/transforms/update-triggerevent-file-param/test.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const { runTransformTest } = require('codemod-cli');
+
+runTransformTest({
+  type: 'jscodeshift',
+  name: 'update-triggerevent-file-param',
+});


### PR DESCRIPTION
### Description
Add a transform to update param in `triggerEvent` from:
```
import { triggerEvent } from '@ember/test-helpers';

test('test', async function(assert) {
    await triggerEvent('[data-test-file-upload-button__input]', 'change', [file]);
});
```
to
```
import { triggerEvent } from '@ember/test-helpers';

test('test', async function(assert) {
    await triggerEvent('[data-test-file-upload-button__input]', 'change', {
        files: [file]
    });
});
```

@rwjblue @simonihmig BTW, is there anyway to generate an inline objectExpression `{files: [file]})` instead of 
```
 {
     files: [file]
 }
```
?